### PR TITLE
Feat/origin dest exclusion filters

### DIFF
--- a/docs/examples/3_crude_from_saudi_arabia_to_india.py
+++ b/docs/examples/3_crude_from_saudi_arabia_to_india.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     one_month_ago = now - relativedelta(months=1)
 
     # First we find the ID for the country India. Note that when searching geographies with the term 'india', we'll
-    # retreive all geographies with india in the name, ie Indiana, British Indian Ocean Territory...
+    # retrieve all geographies with india in the name, ie Indiana, British Indian Ocean Territory...
     all_geogs_with_india_in_the_name = Geographies().search("india").to_list()
 
     # We're only interested in the country India here

--- a/tests/endpoints/test_cargo_movements_real.py
+++ b/tests/endpoints/test_cargo_movements_real.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from docs.utils import to_markdown
 from tests.testcases import TestCaseUsingRealAPI
 from tests.timer import Timer
-from vortexasdk import Geographies, Corporations
+from vortexasdk import Geographies, Corporations, Products
 from vortexasdk.endpoints.cargo_movements import CargoMovements
 
 
@@ -46,6 +46,71 @@ class TestCargoMovementsReal(TestCaseUsingRealAPI):
         )
 
         assert len(df) == 2
+
+    def test_exlusion_filter(self):
+        crude = [
+            p.id
+            for p in Products().search("Crude/Condensates").to_list()
+            if p.layer == ["group"]
+        ]
+        arab_medium = [
+            p.id
+            for p in Products().search("Arab Medium").to_list()
+            if p.layer == ["grade"]
+        ]
+        meg = [
+            g.id
+            for g in Geographies().search("MEG/AG").to_list()
+            if "trading_region" in g.layer
+        ]
+        iraq = [
+            g.id
+            for g in Geographies().search("Iraq").to_list()
+            if "country" in g.layer
+        ]
+
+        cols = [
+            "cargo_movement_id",
+            "vessels.0.name",
+            "events.cargo_port_load_event.0.location.port.id",
+            "events.cargo_port_load_event.0.location.port.label",
+            "events.cargo_port_load_event.0.location.country.id",
+            "events.cargo_port_load_event.0.location.country.label",
+            "events.cargo_port_load_event.0.start_timestamp",
+            "events.cargo_port_load_event.0.end_timestamp",
+            "product.grade.id",
+            "product.grade.label",
+            "product.group_product.label",
+        ]
+
+        df = (
+            CargoMovements()
+            .search(
+                filter_activity="loading_end",
+                filter_products=[
+                    "54af755a090118dcf9b0724c9a4e9f14745c26165385ffa7f1445bc768f06f11"
+                ],
+                filter_origins=meg,
+                exclude={
+                    "filter_origins": iraq,
+                    "filter_products": arab_medium,
+                },
+                filter_time_min=datetime(2019, 10, 1),
+                filter_time_max=datetime(2019, 11, 1),
+                cm_unit="b",
+            )
+            .to_df(columns=cols)
+        )
+
+        df_excl = df.loc[
+            (
+                df["events.cargo_port_load_event.0.location.country.id"]
+                == iraq[0]
+            )
+            | (df["product.grade.id"] == arab_medium[0])
+        ]
+
+        assert df_excl.empty
 
     def test_to_df_all_columns(self):
         df = (

--- a/tests/endpoints/test_cargo_movements_real.py
+++ b/tests/endpoints/test_cargo_movements_real.py
@@ -92,7 +92,7 @@ class TestCargoMovementsReal(TestCaseUsingRealAPI):
                 ],
                 filter_origins=meg,
                 exclude={
-                    "filter_origins": iraq,
+                    "filter_origins": iraq[0],
                     "filter_products": arab_medium,
                 },
                 filter_time_min=datetime(2019, 10, 1),

--- a/tests/endpoints/test_cargo_movements_real.py
+++ b/tests/endpoints/test_cargo_movements_real.py
@@ -91,10 +91,8 @@ class TestCargoMovementsReal(TestCaseUsingRealAPI):
                     "54af755a090118dcf9b0724c9a4e9f14745c26165385ffa7f1445bc768f06f11"
                 ],
                 filter_origins=meg,
-                exclude={
-                    "filter_origins": iraq[0],
-                    "filter_products": arab_medium,
-                },
+                exclude_origins=iraq[0],
+                exclude_products=arab_medium,
                 filter_time_min=datetime(2019, 10, 1),
                 filter_time_max=datetime(2019, 11, 1),
                 cm_unit="b",

--- a/tests/endpoints/test_vessel_movements_real.py
+++ b/tests/endpoints/test_vessel_movements_real.py
@@ -61,7 +61,10 @@ class TestVesselMovementsReal(TestCaseUsingRealAPI):
             VesselMovements()
             .search(
                 filter_origins=meg,
-                exclude={"filter_origins": iraq, "filter_charterers": bahri},
+                exclude={
+                    "filter_origins": iraq,
+                    "filter_charterers": bahri[0],
+                },
                 filter_time_min=datetime(2019, 10, 15),
                 filter_time_max=datetime(2019, 11, 1),
             )

--- a/tests/endpoints/test_vessel_movements_real.py
+++ b/tests/endpoints/test_vessel_movements_real.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from tests.testcases import TestCaseUsingRealAPI
-from vortexasdk import VesselMovements, Geographies
+from vortexasdk import VesselMovements, Geographies, Corporations
 from vortexasdk.endpoints import vessel_movements_result
 
 
@@ -29,6 +29,51 @@ class TestVesselMovementsReal(TestCaseUsingRealAPI):
         )
 
         assert len(v) > 50
+
+    def test_exclusion_filter(self):
+        meg = [
+            g.id
+            for g in Geographies().search("MEG/AG").to_list()
+            if "trading_region" in g.layer
+        ]
+        iraq = [
+            g.id
+            for g in Geographies().search("Iraq").to_list()
+            if "country" in g.layer
+        ]
+        bahri = [c.id for c in Corporations().search("BAHRI").to_list()]
+
+        cols = [
+            "vessel_movement_id",
+            "vessel.name",
+            "start_timestamp",
+            "end_timestamp",
+            "origin.location.country.id",
+            "origin.location.country.label",
+            "destination.location.country.id",
+            "destination.location.country.label",
+            "cargoes.0.product.group.label",
+            "vessel.corporate_entities.charterer.id",
+            "vessel.corporate_entities.charterer.label",
+        ]
+
+        df = (
+            VesselMovements()
+            .search(
+                filter_origins=meg,
+                exclude={"filter_origins": iraq, "filter_charterers": bahri},
+                filter_time_min=datetime(2019, 10, 15),
+                filter_time_max=datetime(2019, 11, 1),
+            )
+            .to_df(columns=cols)
+        )
+
+        mask = (df["origin.location.country.id"] == iraq[0]) | (
+            df["vessel.corporate_entities.charterer.id"] == bahri[0]
+        )
+        df_excl = df.loc[mask]
+
+        assert df_excl.empty
 
     def test_to_df_all_columns(self):
         rotterdam = [

--- a/tests/endpoints/test_vessel_movements_real.py
+++ b/tests/endpoints/test_vessel_movements_real.py
@@ -61,10 +61,8 @@ class TestVesselMovementsReal(TestCaseUsingRealAPI):
             VesselMovements()
             .search(
                 filter_origins=meg,
-                exclude={
-                    "filter_origins": iraq,
-                    "filter_charterers": bahri[0],
-                },
+                exclude_origins=iraq,
+                exclude_charterers=bahri[0],
                 filter_time_min=datetime(2019, 10, 15),
                 filter_time_max=datetime(2019, 11, 1),
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from vortexasdk.utils import (
     convert_to_list,
     convert_values_to_list,
-    convert_values_to_list_abstract,
 )
 
 
@@ -21,10 +20,3 @@ class TestUtils(TestCase):
         expected = {1: [], 2: ["b"], 3: ["c"]}
 
         assert convert_values_to_list(d) == expected
-
-    def test_convert_values_to_list_abstract(self):
-        d = {"a": "v1", "b": "v2", "c": ["v3"]}
-
-        expected = {"a": ["v1"], "b": ["v2"], "c": ["v3"]}
-
-        assert convert_values_to_list_abstract(d) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
-from vortexasdk.utils import convert_to_list, convert_values_to_list
+from vortexasdk.utils import (
+    convert_to_list,
+    convert_values_to_list,
+    convert_values_to_list_abstract,
+)
 
 
 class TestUtils(TestCase):
@@ -17,3 +21,10 @@ class TestUtils(TestCase):
         expected = {1: [], 2: ["b"], 3: ["c"]}
 
         assert convert_values_to_list(d) == expected
+
+    def test_convert_values_to_list_abstract(self):
+        d = {"a": "v1", "b": "v2", "c": ["v3"]}
+
+        expected = {"a": ["v1"], "b": ["v2"], "c": ["v3"]}
+
+        assert convert_values_to_list_abstract(d) == expected

--- a/vortexasdk/client.py
+++ b/vortexasdk/client.py
@@ -81,7 +81,7 @@ class VortexaClient(AbstractVortexaClient):
         ) as pbar:
             with ThreadPool(self._N_THREADS) as pool:
                 logger.info(
-                    f"{total} Results to retreive."
+                    f"{total} Results to retrieve."
                     f" Sending {len(offsets)}"
                     f" post requests in parallel using {self._N_THREADS} threads."
                 )

--- a/vortexasdk/endpoints/cargo_movements.py
+++ b/vortexasdk/endpoints/cargo_movements.py
@@ -1,6 +1,6 @@
 """Cargo Movements Endpoint."""
 from datetime import datetime
-from typing import List, Union, Dict
+from typing import List, Union
 
 from vortexasdk.api import ID
 from vortexasdk.api.shared_types import to_ISODate
@@ -8,7 +8,7 @@ from vortexasdk.endpoints.cargo_movements_result import CargoMovementsResult
 from vortexasdk.endpoints.endpoints import CARGO_MOVEMENTS_RESOURCE
 from vortexasdk.logger import get_logger
 from vortexasdk.operations import Search
-from vortexasdk.utils import convert_to_list, convert_values_to_list_abstract
+from vortexasdk.utils import convert_to_list
 
 logger = get_logger(__name__)
 
@@ -40,7 +40,12 @@ class CargoMovements(Search):
         filter_storage_locations: Union[ID, List[ID]] = None,
         filter_ship_to_ship_locations: Union[ID, List[ID]] = None,
         filter_waypoints: Union[ID, List[ID]] = None,
-        exclude: Dict[ID, Union[ID, List[ID]]] = None,
+        exclude_origins: Union[ID, List[ID]] = None,
+        exclude_destinations: Union[ID, List[ID]] = None,
+        exclude_products: Union[ID, List[ID]] = None,
+        exclude_vessels: Union[ID, List[ID]] = None,
+        exclude_charterers: Union[ID, List[ID]] = None,
+        exclude_owners: Union[ID, List[ID]] = None,
         disable_geographic_exclusion_rules: bool = None,
         timeseries_activity_time_span_min: int = None,
         timeseries_activity_time_span_max: int = None,
@@ -79,9 +84,17 @@ class CargoMovements(Search):
 
             filter_waypoints: A geography ID, or list of geography IDs to filter on.
 
-            exclude: A dictionary where keys are strings that represent the parameter to implement exclusions on and
-                values are IDs or list of IDs that correspond to the entities to be exluded. Dictionary keys must be one of
-                ['filter_origins', 'filter_destinations', 'filter_products', 'filter_vessels', 'filter_charterers', 'filter_owners']
+            exclude_origins: A geography ID, or list of geography IDs to exclude.
+
+            exclude_destinations: A geography ID, or list of geography IDs to exclude.
+
+            exclude_products: A product ID, or list of product IDs to exclude.
+
+            exclude_vessels: A vessel ID, or list of vessel IDs to exclude.
+
+            exclude_charterers: A charterer ID, or list of charterer IDs to exclude.
+
+            exclude_owners: An owner ID, or list of owner IDs to exclude.
 
             disable_geographic_exclusion_rules: This controls a popular industry term "intra-movements" and determines
              the filter behaviour for cargo leaving then entering the same geographic area.
@@ -163,6 +176,15 @@ class CargoMovements(Search):
         [Cargo Movements Endpoint Further Documentation](https://docs.vortexa.com/reference/POST/cargo-movements/search)
 
         """
+        exclude_params = {
+            "filter_origins": convert_to_list(exclude_origins),
+            "filter_destinations": convert_to_list(exclude_destinations),
+            "filter_products": convert_to_list(exclude_products),
+            "filter_vessels": convert_to_list(exclude_vessels),
+            "filter_charterers": convert_to_list(exclude_charterers),
+            "filter_owners": convert_to_list(exclude_owners),
+        }
+
         params = {
             "filter_activity": filter_activity,
             "filter_time_min": to_ISODate(filter_time_min),
@@ -183,7 +205,7 @@ class CargoMovements(Search):
                 filter_ship_to_ship_locations
             ),
             "filter_waypoints": convert_to_list(filter_waypoints),
-            "exclude": convert_values_to_list_abstract(exclude),
+            "exclude": exclude_params,
             "disable_geographic_exclusion_rules": disable_geographic_exclusion_rules,
             "size": self._MAX_PAGE_RESULT_SIZE,
         }

--- a/vortexasdk/endpoints/cargo_movements.py
+++ b/vortexasdk/endpoints/cargo_movements.py
@@ -1,6 +1,6 @@
 """Cargo Movements Endpoint."""
 from datetime import datetime
-from typing import List, Union
+from typing import List, Union, Dict
 
 from vortexasdk.api import ID
 from vortexasdk.api.shared_types import to_ISODate
@@ -8,7 +8,7 @@ from vortexasdk.endpoints.cargo_movements_result import CargoMovementsResult
 from vortexasdk.endpoints.endpoints import CARGO_MOVEMENTS_RESOURCE
 from vortexasdk.logger import get_logger
 from vortexasdk.operations import Search
-from vortexasdk.utils import convert_to_list
+from vortexasdk.utils import convert_to_list, convert_values_to_list_abstract
 
 logger = get_logger(__name__)
 
@@ -40,6 +40,7 @@ class CargoMovements(Search):
         filter_storage_locations: Union[ID, List[ID]] = None,
         filter_ship_to_ship_locations: Union[ID, List[ID]] = None,
         filter_waypoints: Union[ID, List[ID]] = None,
+        exclude: Dict[ID, Union[ID, List[ID]]] = None,
         disable_geographic_exclusion_rules: bool = None,
         timeseries_activity_time_span_min: int = None,
         timeseries_activity_time_span_max: int = None,
@@ -60,7 +61,7 @@ class CargoMovements(Search):
 
             cm_unit: Unit of measurement. Enter 'b' for barrels or 't' for tonnes.
 
-            filter_corporations: A corporation ID, or list of corporation IDs to filter on.
+            filter_charterers: A charterer ID, or list of charterer IDs to filter on.
 
             filter_destinations: A geography ID, or list of geography IDs to filter on.
 
@@ -77,6 +78,10 @@ class CargoMovements(Search):
             filter_ship_to_ship_locations: A geography ID, or list of geography IDs to filter on.
 
             filter_waypoints: A geography ID, or list of geography IDs to filter on.
+
+            exclude: A dictionary where keys are strings that represent the parameter to implement exclusions on and
+                values are IDs or list of IDs that correspond to the entities to be exluded. Dictionary keys must be one of
+                ['filter_origins', 'filter_destinations', 'filter_products', 'filter_vessels', 'filter_charterers', 'filter_owners']
 
             disable_geographic_exclusion_rules: This controls a popular industry term "intra-movements" and determines
              the filter behaviour for cargo leaving then entering the same geographic area.
@@ -178,6 +183,7 @@ class CargoMovements(Search):
                 filter_ship_to_ship_locations
             ),
             "filter_waypoints": convert_to_list(filter_waypoints),
+            "exclude": convert_values_to_list_abstract(exclude),
             "disable_geographic_exclusion_rules": disable_geographic_exclusion_rules,
             "size": self._MAX_PAGE_RESULT_SIZE,
         }

--- a/vortexasdk/endpoints/vessel_movements.py
+++ b/vortexasdk/endpoints/vessel_movements.py
@@ -73,7 +73,7 @@ class VesselMovements(Search):
 
             exclude: A dictionary where keys are strings that represent the parameter to implement exclusions on and
                 values are IDs or list of IDs that correspond to the entities to be exluded. Dictionary keys must be one of
-                ['filter_origins', 'filter_destinations', 'filter_products', 'filter_vessels', 'filter_charterers', 'filter_owners']
+                ['filter_origins', 'filter_destinations', 'filter_products', 'filter_vessels', 'filter_vessel_classes', 'filter_charterers', 'filter_owners']
 
 
         # Returns

--- a/vortexasdk/endpoints/vessel_movements.py
+++ b/vortexasdk/endpoints/vessel_movements.py
@@ -1,13 +1,13 @@
 """Vessel Movements Endpoint."""
 from datetime import datetime
-from typing import List, Union, Dict
+from typing import List, Union
 
 from vortexasdk.api.shared_types import to_ISODate
 from vortexasdk.endpoints.endpoints import VESSEL_MOVEMENTS_RESOURCE
 from vortexasdk.endpoints.vessel_movements_result import VesselMovementsResult
 from vortexasdk.logger import get_logger
 from vortexasdk.operations import Search
-from vortexasdk.utils import convert_to_list, convert_values_to_list_abstract
+from vortexasdk.utils import convert_to_list
 
 logger = get_logger(__name__)
 
@@ -43,7 +43,13 @@ class VesselMovements(Search):
         filter_vessels: Union[str, List[str]] = None,
         filter_vessel_classes: Union[str, List[str]] = None,
         filter_vessel_status: str = None,
-        exclude: Dict[str, Union[str, List[str]]] = None,
+        exclude_origins: Union[str, List[str]] = None,
+        exclude_destinations: Union[str, List[str]] = None,
+        exclude_products: Union[str, List[str]] = None,
+        exclude_vessels: Union[str, List[str]] = None,
+        exclude_vessel_classes: Union[str, List[str]] = None,
+        exclude_charterers: Union[str, List[str]] = None,
+        exclude_owners: Union[str, List[str]] = None,
     ) -> VesselMovementsResult:
         """
         Find VesselMovements matching the given search parameters.
@@ -71,9 +77,19 @@ class VesselMovements(Search):
 
             filter_vessel_status: The vessel status on which to base the filter. Enter 'vessel_status_ballast' for ballast vessels, 'vessel_status_laden_known' for laden vessels with known cargo (i.e. a type of cargo that Vortexa currently tracks) or 'vessel_status_laden_unknown' for laden vessels with unknown cargo (i.e. a type of cargo that Vortexa currently does not track).
 
-            exclude: A dictionary where keys are strings that represent the parameter to implement exclusions on and
-                values are IDs or list of IDs that correspond to the entities to be exluded. Dictionary keys must be one of
-                ['filter_origins', 'filter_destinations', 'filter_products', 'filter_vessels', 'filter_vessel_classes', 'filter_charterers', 'filter_owners']
+            exclude_origins: A geography ID, or list of geography IDs to exclude.
+
+            exclude_destinations: A geography ID, or list of geography IDs to exclude.
+
+            exclude_products: A product ID, or list of product IDs to exclude.
+
+            exclude_vessels: A vessel ID, or list of vessel IDs to exclude.
+
+            exclude_vessel_classes: A vessel class, or list of vessel classes to exclude.
+
+            exclude_charterers: A charterer ID, or list of charterer IDs to exclude.
+
+            exclude_owners: An owner ID, or list of owner IDs to exclude.
 
 
         # Returns
@@ -102,6 +118,16 @@ class VesselMovements(Search):
         [Vessel Movements Endpoint Further Documentation](https://docs.vortexa.com/reference/POST/vessel-movements/search)
 
         """
+        exclude_params = {
+            "filter_origins": convert_to_list(exclude_origins),
+            "filter_destinations": convert_to_list(exclude_destinations),
+            "filter_products": convert_to_list(exclude_products),
+            "filter_vessels": convert_to_list(exclude_vessels),
+            "filter_vessel_classes": convert_to_list(exclude_vessel_classes),
+            "filter_charterers": convert_to_list(exclude_charterers),
+            "filter_owners": convert_to_list(exclude_owners),
+        }
+
         params = {
             "filter_time_min": to_ISODate(filter_time_min),
             "filter_time_max": to_ISODate(filter_time_max),
@@ -114,7 +140,7 @@ class VesselMovements(Search):
             "filter_vessels": convert_to_list(filter_vessels),
             "filter_vessel_classes": convert_to_list(filter_vessel_classes),
             "filter_vessel_status": filter_vessel_status,
-            "exclude": convert_values_to_list_abstract(exclude),
+            "exclude": exclude_params,
             "size": self._MAX_PAGE_RESULT_SIZE,
         }
 

--- a/vortexasdk/endpoints/vessel_movements.py
+++ b/vortexasdk/endpoints/vessel_movements.py
@@ -1,13 +1,13 @@
 """Vessel Movements Endpoint."""
 from datetime import datetime
-from typing import List, Union
+from typing import List, Union, Dict
 
 from vortexasdk.api.shared_types import to_ISODate
 from vortexasdk.endpoints.endpoints import VESSEL_MOVEMENTS_RESOURCE
 from vortexasdk.endpoints.vessel_movements_result import VesselMovementsResult
 from vortexasdk.logger import get_logger
 from vortexasdk.operations import Search
-from vortexasdk.utils import convert_to_list
+from vortexasdk.utils import convert_to_list, convert_values_to_list_abstract
 
 logger = get_logger(__name__)
 
@@ -43,6 +43,7 @@ class VesselMovements(Search):
         filter_vessels: Union[str, List[str]] = None,
         filter_vessel_classes: Union[str, List[str]] = None,
         filter_vessel_status: str = None,
+        exclude: Dict[str, Union[str, List[str]]] = None,
     ) -> VesselMovementsResult:
         """
         Find VesselMovements matching the given search parameters.
@@ -54,7 +55,7 @@ class VesselMovements(Search):
 
             unit: Unit of measurement. Enter 'b' for barrels or 't' for tonnes.
 
-            filter_corporations: A corporation ID, or list of corporation IDs to filter on.
+            filter_charterers: A charterer ID, or list of charterer IDs to filter on.
 
             filter_destinations: A geography ID, or list of geography IDs to filter on.
 
@@ -69,6 +70,11 @@ class VesselMovements(Search):
             filter_vessel_classes: A vessel class, or list of vessel classes to filter on.
 
             filter_vessel_status: The vessel status on which to base the filter. Enter 'vessel_status_ballast' for ballast vessels, 'vessel_status_laden_known' for laden vessels with known cargo (i.e. a type of cargo that Vortexa currently tracks) or 'vessel_status_laden_unknown' for laden vessels with unknown cargo (i.e. a type of cargo that Vortexa currently does not track).
+
+            exclude: A dictionary where keys are strings that represent the parameter to implement exclusions on and
+                values are IDs or list of IDs that correspond to the entities to be exluded. Dictionary keys must be one of
+                ['filter_origins', 'filter_destinations', 'filter_products', 'filter_vessels', 'filter_charterers', 'filter_owners']
+
 
         # Returns
         `VesselMovementsResult`, containing all the vessel movements matching the given search terms.
@@ -108,6 +114,7 @@ class VesselMovements(Search):
             "filter_vessels": convert_to_list(filter_vessels),
             "filter_vessel_classes": convert_to_list(filter_vessel_classes),
             "filter_vessel_status": filter_vessel_status,
+            "exclude": convert_values_to_list_abstract(exclude),
             "size": self._MAX_PAGE_RESULT_SIZE,
         }
 

--- a/vortexasdk/utils.py
+++ b/vortexasdk/utils.py
@@ -14,14 +14,3 @@ def convert_to_list(a) -> List:
 def convert_values_to_list(data: Dict) -> Dict:
     """Convert each value to a list."""
     return {k: convert_to_list(v) for k, v in data.items()}
-
-
-def convert_values_to_list_abstract(a) -> Dict:
-    """ If element is None returns empty dict else converts each value to list if it isn't a list already."""
-    if isinstance(a, dict):
-        for k, v in a.items():
-            if not isinstance(v, list):
-                a[k] = convert_to_list(v)
-        return a
-    else:
-        return {}

--- a/vortexasdk/utils.py
+++ b/vortexasdk/utils.py
@@ -14,3 +14,14 @@ def convert_to_list(a) -> List:
 def convert_values_to_list(data: Dict) -> Dict:
     """Convert each value to a list."""
     return {k: convert_to_list(v) for k, v in data.items()}
+
+
+def convert_values_to_list_abstract(a) -> Dict:
+    """ If element is None returns empty dict else converts each value to list if it isn't a list already."""
+    if isinstance(a, dict):
+        for k, v in a.items():
+            if not isinstance(v, list):
+                a[k] = convert_to_list(v)
+        return a
+    else:
+        return {}


### PR DESCRIPTION
Add exclusion filters to `CargoMovements` and `VesselMovements` endpoints. Closes [#168 ](https://github.com/VorTECHsa/python-sdk/issues/168) and on top includes all possible 'exclude' filters (e..g. excluce charterers, owners, products etc.)