### PR TITLE
feat: Exact term match

### DIFF
--- a/tests/endpoints/test_products_real.py
+++ b/tests/endpoints/test_products_real.py
@@ -26,9 +26,13 @@ class TestProductsReal(TestCaseUsingRealAPI):
         # Confirm that searching our search term does indeed yield more than one result
         products = Products().search(search_term).to_list()
         if len(products) <= 1:
-            raise Exception(f"Unable to perform exact match test on {search_term}.")
+            raise Exception(
+                f"Unable to perform exact match test on {search_term}."
+            )
 
-        products_exact = Products().search(search_term, exact_term_match=True).to_list()
+        products_exact = (
+            Products().search(search_term, exact_term_match=True).to_list()
+        )
 
         assert {p.name for p in products_exact} == {search_term}
 
@@ -40,10 +44,10 @@ class TestProductsReal(TestCaseUsingRealAPI):
     def test_search_multiple_terms_to_dataframe(self):
         df = (
             Products()
-                .search(
+            .search(
                 term=["diesel", "fuel oil", "grane", "lng", "lpg", "crude"]
             )
-                .to_df("all")
+            .to_df("all")
         )
 
         expected_columns = {

--- a/tests/endpoints/test_products_real.py
+++ b/tests/endpoints/test_products_real.py
@@ -20,6 +20,18 @@ class TestProductsReal(TestCaseUsingRealAPI):
         assert list(df.columns) == ["name", "id"]
         assert len(df) > 0
 
+    def test_search_exact_match(self):
+        search_term = "Gasoil"
+
+        # Confirm that searching our search term does indeed yield more than one result
+        products = Products().search(search_term).to_list()
+        if len(products) <= 1:
+            raise Exception(f"Unable to perform exact match test on {search_term}.")
+
+        products_exact = Products().search(search_term, exact_term_match=True).to_list()
+
+        assert {p.name for p in products_exact} == {search_term}
+
     def test_load_all(self):
         all_products = Products().load_all()
 
@@ -28,10 +40,10 @@ class TestProductsReal(TestCaseUsingRealAPI):
     def test_search_multiple_terms_to_dataframe(self):
         df = (
             Products()
-            .search(
+                .search(
                 term=["diesel", "fuel oil", "grane", "lng", "lpg", "crude"]
             )
-            .to_df("all")
+                .to_df("all")
         )
 
         expected_columns = {

--- a/vortexasdk/utils.py
+++ b/vortexasdk/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Union
 import json
 from urllib.request import urlopen
 from distutils.version import LooseVersion
@@ -19,6 +19,21 @@ def convert_to_list(a) -> List:
 def convert_values_to_list(data: Dict) -> Dict:
     """Convert each value to a list."""
     return {k: convert_to_list(v) for k, v in data.items()}
+
+
+def filter_exact_match(
+    allowed_name: Union[str, List[str]], search_result: List[Dict]
+) -> List[Dict]:
+    """
+    Filter search results on items with exact matching names.
+
+    # Arguments
+        allowed_name: An allowed name, or list of allowed names
+        search_result: A list of dictionaries. Each dictionary must contain the key "name".
+
+    """
+    allowed_names_list = convert_to_list(allowed_name)
+    return [s for s in search_result if s["name"] in allowed_names_list]
 
 
 def filter_empty_values(data: Dict) -> Dict:


### PR DESCRIPTION
Allow the user to filter on only exact name matches.

If we're happy with this implementation, then I'll add similar logic to the Vessels, Corporations, and Geographies endpoints.