### PR TITLE
Chore: Set default log level to WARNING

### DIFF
--- a/vortexasdk/config.py
+++ b/vortexasdk/config.py
@@ -1,4 +1,4 @@
 import os
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_LEVEL = os.getenv("LOG_LEVEL", "ERROR").upper()
 LOG_FILE = os.getenv("LOG_FILE", None)

--- a/vortexasdk/config.py
+++ b/vortexasdk/config.py
@@ -1,4 +1,4 @@
 import os
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "ERROR").upper()
+LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING").upper()
 LOG_FILE = os.getenv("LOG_FILE", None)


### PR DESCRIPTION
INFO level logs bloat notebooks, and the SDK is stable enough now that we don't need INFO by default.

Users can still set INFO level by setting the LOG_LEVEL env var.