### PR TITLE
ci: Run examples as part of ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,16 @@ jobs:
             pytest -v --doctest-modules
 
       - run:
+          name: "Run all examples"
+          command: |
+            . .venv/bin/activate
+            for f in docs/examples/*.py; do cp -v -- "$f" "$f-example.py"; done
+            cp docs/examples/*-example.py .
+            for f in *-example.py; do echo python "$f"; done
+            rm docs/examples/*-example.py
+            rm *-example.py
+
+      - run:
           name: "Confirm that the check_setup script works"
           command: |
             . .venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,11 @@ jobs:
       - run:
           name: "Run all examples"
           command: |
+            set -xe
             . .venv/bin/activate
             for f in docs/examples/*.py; do cp -v -- "$f" "$f-example.py"; done
             cp docs/examples/*-example.py .
-            for f in *-example.py; do echo python "$f"; done
+            for f in *-example.py; do python "$f"; done
             rm docs/examples/*-example.py
             rm *-example.py
 

--- a/docs/examples/1_china.py
+++ b/docs/examples/1_china.py
@@ -17,9 +17,6 @@ from datetime import datetime
 from vortexasdk import CargoMovements, Geographies, Vessels
 
 if __name__ == "__main__":
-
-    raise ImportError("This should fail ci")
-
     # Find china ID
     china = [
         g.id

--- a/docs/examples/1_china.py
+++ b/docs/examples/1_china.py
@@ -17,6 +17,9 @@ from datetime import datetime
 from vortexasdk import CargoMovements, Geographies, Vessels
 
 if __name__ == "__main__":
+
+    raise ImportError("This should fail ci")
+
     # Find china ID
     china = [
         g.id

--- a/docs/examples/7_custom_excel_charterer_ingestion.py
+++ b/docs/examples/7_custom_excel_charterer_ingestion.py
@@ -46,7 +46,7 @@ def convert_to_corporation_ids(corporation_name: str) -> List[ID]:
 
 if __name__ == "__main__":
     # Read our excel sheet of charterers into a dataframe
-    charterers_df = pd.read_excel("./resources/my_charterers.xlsx")
+    charterers_df = pd.read_excel("./docs/examples/resources/my_charterers.xlsx")
 
     # Convert the charterer names into ids
     charterers_list_of_lists = charterers_df['charterers'].apply(convert_to_corporation_ids).to_list()

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
             "pydoc-markdown==2.0.5",
             "tabulate==0.8.5",
             "six==1.12.0",
+            "xlrd==1.2.0"
         ]
     },
 )


### PR DESCRIPTION
Currently the SDK has potential for big boo boo if we've got failing documented examples up, and we'd never realise as these aren't run in the ci.

This PR fixes that.

1. We copy the examples to the root dir (this means we can run them as a client would, and the examples can have `from vortexasdk import ...`, so the `vortexasdk` module has the right relative path for imports.
2. Run the examples
3. Cleanup