### PR TITLE
fix: set all_test_pass to False if API KEY not found

### DIFF
--- a/vortexasdk/check_setup.py
+++ b/vortexasdk/check_setup.py
@@ -10,6 +10,7 @@ def check_api_key_present():
     global all_tests_pass
     api_key = os.getenv("VORTEXA_API_KEY")
     if api_key is None:
+        all_tests_pass = False
         print("🔸 Environment variable VORTEXA_API_KEY is not set.")
         print(
             "         Please set this environment variable, this is the recommended way to authenticate with the SDK."


### PR DESCRIPTION
`check_setup.py` script does not set `all_test_pass` flag to False if the API key is not found.

Solution: Set to false if not found.