### PR TITLE
Unpin dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
           command: |
             . .venv/bin/activate
             pip install tox
-            tox  --parallel --verbose
+            tox  -o --verbose
 
   check-release-version:
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
     working_directory: ~/project
     docker:
       - image: circleci/python:3.7
-    resource_class: 2xlarge
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache: &restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
     working_directory: ~/project
     docker:
       - image: circleci/python:3.7
+    resource_class: 2xlarge
     steps:
       - checkout
       - restore_cache: &restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           command: |
             . .venv/bin/activate
             pip install tox
-            tox  -o
+            TOX_PARALLEL_NO_SPINNER=1 tox  -p 8
 
   check-release-version:
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           command: |
             . .venv/bin/activate
             pip install tox
-            TOX_PARALLEL_NO_SPINNER=1 tox  -p 8
+            tox -p -o --verbose
 
   check-release-version:
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           command: |
             . .venv/bin/activate
             pip install tox
-            tox  -o --verbose
+            tox  -o
 
   check-release-version:
     working_directory: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ jobs:
             python docs/autogen.py
             pydocmd build
 
-
   run-examples:
     working_directory: ~/project
     docker:
@@ -130,7 +129,7 @@ jobs:
           command: |
             . .venv/bin/activate
             pip install tox
-            tox --verbose
+            tox  --parallel --verbose
 
   check-release-version:
     working_directory: ~/project
@@ -185,7 +184,6 @@ jobs:
             git tag -a $TAG -m "New tag $TAG"
             git push --tags
 
-
 workflows:
   version: 2
   build-deploy:
@@ -194,19 +192,19 @@ workflows:
 
       - lint:
           requires:
-              - build
+            - build
 
       - test:
           requires:
-              - build
+            - build
 
       - test-documentation:
           requires:
-              - build
+            - build
 
       - run-examples:
           requires:
-              - build
+            - build
 
       - check-release-version:
           requires:

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,14 @@ setuptools.setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "flatten-dict==0.2.0",
-        "jsons==1.0.0",
-        "jupyter==1.0.0",
-        "matplotlib==3.3.4",
-        "pandas>=0.25.2",
-        "requests==2.22.0",
-        "statsmodels==0.12.2",
-        "tqdm==4.38.0",
+        "flatten-dict~=0.2.0",
+        "jsons~=1.0.0",
+        "jupyter~=1.0.0",
+        "matplotlib~=3.3.4",
+        "pandas>=0.25.2,<=1.3.0",
+        "requests>=2.22.0,<=2.26.0",
+        "statsmodels~=0.12.2",
+        "tqdm~=4.38.0",
     ],
     extras_require={
         "tests": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
 envlist = 
-    py37-pandas{0252,100,110,120,130}, py37-requests{222,223,224,225,226}
+    py37-pandas{0252,100,110,120,130}-requests{222,223,224,225,226}
 
 [testenv]
 deps =
+    -e .
+    -e .[tests]
+    
     pandas0252: pandas==0.25.2
     pandas100: pandas==1.0.0
     pandas110: pandas==1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ envlist =
 
 [testenv]
 deps =
-    -e .
-    -e .[tests]
-    
+    -e.
+    -e.[tests]
+
     pandas0252: pandas==0.25.2
     pandas100: pandas==1.0.0
     pandas110: pandas==1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py{37}-pandas{0252,100,110,120,130}-requests{222,223,224,225,226}
+envlist = 
+    py37-pandas{0252,100,110,120,130}, py37-requests{222,223,224,225,226}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,18 @@
 [tox]
-envlist = py37-pandas{0252,100}
+envlist = py{37}-pandas{0252,100,110,120,130}-requests{222,223,224,225,226}
 
 [testenv]
 deps =
     pandas0252: pandas==0.25.2
     pandas100: pandas==1.0.0
+    pandas110: pandas==1.1.0
+    pandas120: pandas==1.2.0
+    pandas130: pandas==1.3.0
+    requests222: requests==2.22.0
+    requests223: requests==2.23.0
+    requests224: requests==2.24.0
+    requests225: requests==2.25.0
+    requests226: requests==2.26.0
     .[tests]
 commands = pytest
 passenv = VORTEXA_API_KEY


### PR DESCRIPTION
The package dependencies of this library are pinned, which is fine in a majority of cases if used exclusively in a notebook environment, but suboptimal if part of a production process. The direct effect of this limitation is that, for example, one is not able to use newer versions of libraries that require `requests`.

Of course, unpinning should be done in a controlled way, ensuring that the code still works in any permutation of dependency versions. Therefore, I propose the following changes:

### 1. Unpin dependencies
From:
```
"flatten-dict==0.2.0",
 "jsons==1.0.0",
 "jupyter==1.0.0",
 "matplotlib==3.3.4",
 "pandas>=0.25.2",
 "requests==2.22.0",
 "statsmodels==0.12.2",
 "tqdm==4.38.0",
```

To:
```
"flatten-dict~=0.2.0",
 "jsons~=1.0.0",
 "jupyter~=1.0.0",
 "matplotlib~=3.3.4",
 "pandas>=0.25.2,<=1.3.0",
 "requests>=2.22.0,<=2.26.0",
 "statsmodels~=0.12.2",
 "tqdm~=4.38.0",
```

Some dependencies are relaxed to `compatible`, some are given a range. In any case, `pandas` and `requests` are the main pain-points.

### 2.  Test more comprehensively with tox
In the current setup, we only test two scenarios - pandas 0.25 and pandas 1.0 (so we run the tests twice). Given the range of versions the requirements have been relaxed to, we should instead test all combinations of minor versions in the range of supported versions for `pandas` and `requests`. This means now we have to run the test suite 25 times.

The result of this is that, even with the addition of the `-o` flag to tox, which executes tests environments in parallel (albeit with only 2 instances since our provisioned CI executor has 2cpus), testing takes over 2 hours.

What can we do to address this? Well, I think we have a couple of options:
1. Test fewer scenarios (maybe fix the version of `requests` for all the `pandas` variations and vice-versa, bringing the number down to 10 suites).
2. Increase the size of the executor. Assuming almost linear scaling, we should be able to bring this down to 30 mins (from the original ~15 before this PR) with an 8-cpus instance.
