### PR TITLE
docs: clarify docs for BLNG Freight Pricing routes

### DIFF
--- a/vortexasdk/endpoints/freight_pricing_search.py
+++ b/vortexasdk/endpoints/freight_pricing_search.py
@@ -45,10 +45,11 @@ class FreightPricingSearch(Search):
             - BLNG routes -  `BLNG1g`, `BLNG2g`, `BLNG3g`
 
             days: Used to filter results by day on which the record was generated. Must be an ISO date array or not supplied.
+            Note that BLNG prices are only published on Tuesdays and Fridays.
 
-            order: Used to sort the returned results. Must be either 'record_date' or not supplied.
+            order: Used to sort the returned results. Must be either `record_date` or not supplied.
 
-            order_direction: Determines the direction of sorting. ‘asc’ for ascending, ‘desc’ for
+            order_direction: Determines the direction of sorting. `asc` for ascending, `desc` for
             descending.
 
             size: Used to page results. The size of the result set. Between 0 and 500.

--- a/vortexasdk/endpoints/freight_pricing_timeseries.py
+++ b/vortexasdk/endpoints/freight_pricing_timeseries.py
@@ -39,14 +39,16 @@ class FreightPricingTimeseries(Search):
 
              time_max: The UTC end date of the time filter.
 
-             breakdown_frequency: Must be one of: `'day'`, `'week'`, `'doe_week'`, `'month'`, `'quarter'` or `'year'`.
+             breakdown_frequency: Must be one of: `day`, `week`, `doe_week`, `month`, `quarter` or `year`.
 
-             breakdown_property: Property used to build the value of the aggregation. Must be one of the following: `route`, `cost`, `tce`.
+             breakdown_property: Property used to build the value of the aggregation. Must be one of the following:
+             `route`, `cost` (non-LNG routes), `tce` (non-LNG routes).
 
              routes: Used to filter by specific routes. Must be one of the following:
              - Clean routes - `TC1`, `TC2_37`, `TC5`, `TC6`, `TC7`, `TC8`, `TC9`, `TC10`, `TC11`, `TC12`, `TC14`, `TC15`, `TC16`, `TC17`, `TC18`, `TC19`.
              - Dirty routes - `TD1`, `TD2`, `TD3C`, `TD6`, `TD7`, `TD8`, `TD9`, `TD12`, `TD14`, `TD15`, `TD17`, `TD18`, `TD19`, `TD20`, `TD21`, `TD22`, `TD23`, `TD24`, `TD25`, `TD26`.
              - BLPG routes - `BLPG1`, `BLPG2`, `BLPG3`.
+             - BLNG routes - `BLNG1g`, `BLNG2g`, `BLNG3g`.
 
          # Returns
          `TimeSeriesResult`

--- a/vortexasdk/endpoints/freight_pricing_timeseries.py
+++ b/vortexasdk/endpoints/freight_pricing_timeseries.py
@@ -42,7 +42,7 @@ class FreightPricingTimeseries(Search):
              breakdown_frequency: Must be one of: `day`, `week`, `doe_week`, `month`, `quarter` or `year`.
 
              breakdown_property: Property used to build the value of the aggregation. Must be one of the following:
-             `route`, `cost` (non-LNG routes), `tce` (non-LNG routes).
+             `route`, `cost` (not available for LNG routes), `tce` (not available for LNG routes).
 
              routes: Used to filter by specific routes. Must be one of the following:
              - Clean routes - `TC1`, `TC2_37`, `TC5`, `TC6`, `TC7`, `TC8`, `TC9`, `TC10`, `TC11`, `TC12`, `TC14`, `TC15`, `TC16`, `TC17`, `TC18`, `TC19`.


### PR DESCRIPTION
#### RELATED TICKETS

- https://vortexa.atlassian.net/browse/RND-10672

#### CHANGELOG

- Include BLNG route options in FP time-series docs
- Include note that `cost` and `tce` breakdowns for FP time-series are not supported for LNG routes.

#### TESTS

- N/A

#### COMMENTS

- N/A
