### PR TITLE
chore: upgrade pydantic but use v1 fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
             "flake8==3.7.9",
             "black==22.8.0",
             "mkdocs==1.2.4",
-            "mypy==1.13.0",
+            "mypy>1.0.0",
             "pre-commit==1.20.0",
             "pytest==5.2.4",
             "pydoc-markdown==2.0.5",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "flatten-dict==0.4.2",
         "pandas>=0.25.2",
         "requests==2.31.0",
-        "pydantic>=2",
+        "pydantic>=2.0.0,<3.0.0",
         "tqdm==4.64.1",
         "urllib3>=1.26",
     ],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
             "flake8==3.7.9",
             "black==22.8.0",
             "mkdocs==1.2.4",
-            "mypy==0.971",
+            "mypy==1.13.0",
             "pre-commit==1.20.0",
             "pytest==5.2.4",
             "pydoc-markdown==2.0.5",

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setuptools.setup(
         "flatten-dict==0.4.2",
         "pandas>=0.25.2",
         "requests==2.31.0",
-        "pydantic>=1.10.2,<2",
+        "pydantic>=2",
         "tqdm==4.64.1",
-        "urllib3>=1.26"
+        "urllib3>=1.26",
     ],
     extras_require={
         "tests": [
@@ -53,12 +53,12 @@ setuptools.setup(
             "types-six==1.16.19",
             "jupyter==1.0.0",
             "statsmodels==0.13.2",
-            "matplotlib>=3.5.3"
+            "matplotlib>=3.5.3",
         ],
         "binder": [
             "jupyter==1.0.0",
             "statsmodels==0.13.2",
-            "matplotlib>=3.5.3"
+            "matplotlib>=3.5.3",
         ],
         "deploy": ["wheel==0.37.1", "twine==4.0.1"],
     },

--- a/vortexasdk/api/aggregation_breakdown_item.py
+++ b/vortexasdk/api/aggregation_breakdown_item.py
@@ -1,10 +1,10 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 
 from vortexasdk.api.id import ID
 
 
-class AggregationBreakdownItem(BaseModel):
+class AggregationBreakdownItem(pydantic_v1.BaseModel):
     """
     Generic container class holding a `id <> value` pair, a `count` a `label`.
 

--- a/vortexasdk/api/asset_tank.py
+++ b/vortexasdk/api/asset_tank.py
@@ -1,23 +1,23 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import List, Optional
 
 
 from vortexasdk.api.shared_types import ISODate
 
 
-class CorporateEntity(BaseModel):
+class CorporateEntity(pydantic_v1.BaseModel):
     id: Optional[str] = None
     label: Optional[str] = None
     layer: Optional[str] = None
 
 
-class LocationDetails(BaseModel):
+class LocationDetails(pydantic_v1.BaseModel):
     id: Optional[str] = None
     label: Optional[str] = None
     layer: Optional[str] = None
 
 
-class AssetTank(BaseModel):
+class AssetTank(pydantic_v1.BaseModel):
     """
     Represents an Asset Tank reference record returned by the API.
     """

--- a/vortexasdk/api/breakdown_item.py
+++ b/vortexasdk/api/breakdown_item.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import Dict, List, Optional
 
 
-class BreakdownItem(BaseModel):
+class BreakdownItem(pydantic_v1.BaseModel):
     """
     Generic container class holding a `key <> value` pair, a `count`, and optionally a `label` and a `breakdown` of records contributing to the given value.
 

--- a/vortexasdk/api/canal_transit.py
+++ b/vortexasdk/api/canal_transit.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import List, Optional
 
 from vortexasdk.api.geography import GeographyEntity
@@ -11,7 +11,7 @@ from vortexasdk.api.shared_types import (
 from vortexasdk.api.id import ID
 
 
-class CargoEntity(BaseModel):
+class CargoEntity(pydantic_v1.BaseModel):
     cargo_movement_id: ID
     quantity_barrels: Optional[int]
     quantity_tonnes: Optional[int]
@@ -19,19 +19,19 @@ class CargoEntity(BaseModel):
     product: Optional[List[EntityWithSingleLayer]]
 
 
-class GeographyRecord(BaseModel):
+class GeographyRecord(pydantic_v1.BaseModel):
     id: ID
     layer: Optional[List[str]] = None
     label: Optional[str] = None
     aliases: Optional[List[str]] = None
 
 
-class CorporateRecord(BaseModel):
+class CorporateRecord(pydantic_v1.BaseModel):
     id: ID
     label: str
 
 
-class CanalTransitRecord(BaseModel):
+class CanalTransitRecord(pydantic_v1.BaseModel):
     """
 
     The canal transits dataset contains information about ships waiting to cross major global canals.

--- a/vortexasdk/api/cargo_movement.py
+++ b/vortexasdk/api/cargo_movement.py
@@ -1,5 +1,4 @@
-from pydantic import Field
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import List, Optional, Union
 from typing_extensions import Annotated, Literal
 
@@ -10,12 +9,12 @@ from vortexasdk.api.id import ID
 from vortexasdk.api.vessel import VesselEntity
 
 
-class RawLocations(BaseModel):
+class RawLocations(pydantic_v1.BaseModel):
     probability: Optional[float] = None
     location_id: Optional[str] = None
 
 
-class CargoPortLoadEvent(BaseModel):
+class CargoPortLoadEvent(pydantic_v1.BaseModel):
     vessel_id: Optional[ID] = None
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_port_load_event"]] = None
@@ -25,7 +24,7 @@ class CargoPortLoadEvent(BaseModel):
     pos: Optional[List[float]] = None
 
 
-class CargoFSOLoadEvent(BaseModel):
+class CargoFSOLoadEvent(pydantic_v1.BaseModel):
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_fso_load_event"]] = None
     location: Optional[List[GeographyEntity]] = None
@@ -38,7 +37,7 @@ class CargoFSOLoadEvent(BaseModel):
     pos: Optional[List[float]] = None
 
 
-class CargoPortUnloadEvent(BaseModel):
+class CargoPortUnloadEvent(pydantic_v1.BaseModel):
     vessel_id: Optional[ID] = None
     event_type: Optional[Literal["cargo_port_unload_event"]] = None
     location: Optional[List[GeographyEntity]] = None
@@ -50,7 +49,7 @@ class CargoPortUnloadEvent(BaseModel):
     restricted: Optional[bool] = False
 
 
-class CargoFSOUnloadEvent(BaseModel):
+class CargoFSOUnloadEvent(pydantic_v1.BaseModel):
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_fso_unload_event"]] = None
     location: Optional[List[GeographyEntity]] = None
@@ -63,13 +62,13 @@ class CargoFSOUnloadEvent(BaseModel):
     pos: Optional[List[float]] = None
 
 
-class CargoFixtureEvent(BaseModel):
+class CargoFixtureEvent(pydantic_v1.BaseModel):
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_fixture_event"]] = None
     end_timestamp: Optional[ISODate] = None
 
 
-class CargoSTSEvent(BaseModel):
+class CargoSTSEvent(pydantic_v1.BaseModel):
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_sts_event"]] = None
     location: Optional[List[GeographyEntity]] = None
@@ -81,7 +80,7 @@ class CargoSTSEvent(BaseModel):
     pos: Optional[List[float]] = None
 
 
-class CargoStorageEvent(BaseModel):
+class CargoStorageEvent(pydantic_v1.BaseModel):
     vessel_id: Optional[ID] = None
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_storage_event"]] = None
@@ -91,7 +90,7 @@ class CargoStorageEvent(BaseModel):
     pos: Optional[List[float]] = None
 
 
-class CargoWaypointEvent(BaseModel):
+class CargoWaypointEvent(pydantic_v1.BaseModel):
     vessel_id: Optional[ID] = None
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_waypoint_event"]] = None
@@ -101,19 +100,19 @@ class CargoWaypointEvent(BaseModel):
     pos: Optional[List[float]] = None
 
 
-class CargoTransitingEvent(BaseModel):
+class CargoTransitingEvent(pydantic_v1.BaseModel):
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_transiting_event"]] = None
     end_timestamp: Optional[ISODate] = None
 
 
-class CargoOilOnWaterEvent(BaseModel):
+class CargoOilOnWaterEvent(pydantic_v1.BaseModel):
     start_timestamp: Optional[ISODate] = None
     event_type: Optional[Literal["cargo_oil_on_water_event"]] = None
     end_timestamp: Optional[ISODate] = None
 
 
-class ParentID(BaseModel):
+class ParentID(pydantic_v1.BaseModel):
     """
 
     `cargo_movement_id` may change under certain conditions. `ParentID` contains an `id`,
@@ -127,7 +126,7 @@ class ParentID(BaseModel):
     splinter_timestamp: Optional[ISODate] = None
 
 
-class CargoMovementProductEntry(BaseModel):
+class CargoMovementProductEntry(pydantic_v1.BaseModel):
     probability: Optional[float] = None
     source: Optional[str] = None
     id: Optional[ID] = None
@@ -135,7 +134,7 @@ class CargoMovementProductEntry(BaseModel):
     label: Optional[str] = None
 
 
-class CargoMovement(BaseModel):
+class CargoMovement(pydantic_v1.BaseModel):
     """
 
     Cargo movements are the base data set the Vortexa API is centred around.
@@ -167,7 +166,7 @@ class CargoMovement(BaseModel):
                     CargoTransitingEvent,
                     CargoOilOnWaterEvent,
                 ],
-                Field(discriminator="event_type"),
+                pydantic_v1.Field(discriminator="event_type"),
             ]
         ]
     ] = None

--- a/vortexasdk/api/eia_forecast.py
+++ b/vortexasdk/api/eia_forecast.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import Optional
 
 
-class EIAForecast(BaseModel):
+class EIAForecast(pydantic_v1.BaseModel):
     """Represent a EIA forecast record returned by the API."""
 
     date: Optional[str] = None

--- a/vortexasdk/api/fixture.py
+++ b/vortexasdk/api/fixture.py
@@ -1,15 +1,15 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import Optional
 from vortexasdk.api.id import ID
 from vortexasdk.api.vessel import VesselEntity
 
 
-class Entity(BaseModel):
+class Entity(pydantic_v1.BaseModel):
     id: Optional[str] = None
     label: Optional[str] = None
 
 
-class Fixture(BaseModel):
+class Fixture(pydantic_v1.BaseModel):
     """Represent a Fixture record returned by the API."""
 
     id: ID

--- a/vortexasdk/api/freight_pricing.py
+++ b/vortexasdk/api/freight_pricing.py
@@ -1,16 +1,16 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import List, Optional
 from vortexasdk.api.id import ID
 from vortexasdk.api.shared_types import ISODate
 
 
-class FreightPricingPrediction(BaseModel):
+class FreightPricingPrediction(pydantic_v1.BaseModel):
     prediction: Optional[str] = None
     prediction_type: Optional[str] = None
     rating: Optional[str] = None
 
 
-class FreightPricing(BaseModel):
+class FreightPricing(pydantic_v1.BaseModel):
     """
     Freight pricing shows pricing information applicable to a selected route on a given day.
     """

--- a/vortexasdk/api/geography.py
+++ b/vortexasdk/api/geography.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import List, Optional, Tuple
 
 
@@ -13,7 +13,7 @@ from vortexasdk.api.shared_types import (
 Position = Tuple[float, float]
 
 
-class BoundingBox(BaseModel):
+class BoundingBox(pydantic_v1.BaseModel):
     """Polygon with list of bounding lon lat coords."""
 
     type: Optional[str] = None

--- a/vortexasdk/api/onshore_inventory.py
+++ b/vortexasdk/api/onshore_inventory.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import List, Optional
 
 from vortexasdk.api.asset_tank import AssetTank
@@ -7,7 +7,7 @@ from vortexasdk.api.shared_types import ISODate
 from vortexasdk.api.id import ID
 
 
-class OnshoreInventory(BaseModel):
+class OnshoreInventory(pydantic_v1.BaseModel):
     """
 
     Land Storage measurements are the base data set the Vortexa API is centred around.

--- a/vortexasdk/api/search_result.py
+++ b/vortexasdk/api/search_result.py
@@ -1,15 +1,15 @@
 from typing_extensions import Literal
-from pydantic import BaseModel, Field
+from pydantic import v1 as pydantic_v1
 from typing import Any, Dict, List, Union
 
 import pandas as pd
 
 
-class Result(BaseModel):
+class Result(pydantic_v1.BaseModel):
     """Abstract Container that holds a list of *records*."""
 
-    records: List = Field(default_factory=list)
-    reference: Dict[str, Any] = Field(default_factory=dict)
+    records: List = pydantic_v1.Field(default_factory=list)
+    reference: Dict[str, Any] = pydantic_v1.Field(default_factory=dict)
 
     def to_list(self) -> List:
         """Represent *records* as a list."""

--- a/vortexasdk/api/shared_types.py
+++ b/vortexasdk/api/shared_types.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from enum import Enum
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
+
 from datetime import datetime
 from typing import List, Optional, Union
 
@@ -20,7 +21,7 @@ def to_ISODate_Array(days: List[datetime]) -> List[ISODate]:
     return [to_ISODate(date) for date in days]
 
 
-class EntityWithSingleLayer(BaseModel):
+class EntityWithSingleLayer(pydantic_v1.BaseModel):
     """Holds commonly used properties."""
 
     id: ID
@@ -28,7 +29,7 @@ class EntityWithSingleLayer(BaseModel):
     label: Optional[str] = None
 
 
-class EntityWithSingleLayerAndTimespan(BaseModel):
+class EntityWithSingleLayerAndTimespan(pydantic_v1.BaseModel):
     id: ID
     layer: Optional[str] = None
     label: Optional[str] = None
@@ -36,7 +37,7 @@ class EntityWithSingleLayerAndTimespan(BaseModel):
     end_timestamp: Optional[ISODate] = None
 
 
-class EntityWithListLayer(BaseModel):
+class EntityWithListLayer(pydantic_v1.BaseModel):
     """Holds commonly used properties."""
 
     id: ID
@@ -44,7 +45,7 @@ class EntityWithListLayer(BaseModel):
     label: Optional[str] = None
 
 
-class EntityWithSingleLayerAndProbability(BaseModel):
+class EntityWithSingleLayerAndProbability(pydantic_v1.BaseModel):
     """
     Extension of `Entity`, containing additional properties.
 
@@ -59,7 +60,7 @@ class EntityWithSingleLayerAndProbability(BaseModel):
     label: Optional[str] = None
 
 
-class EntityWithListLayerAndProbability(BaseModel):
+class EntityWithListLayerAndProbability(pydantic_v1.BaseModel):
     """
     Extension of `Entity`, containing additional properties.
 
@@ -74,14 +75,14 @@ class EntityWithListLayerAndProbability(BaseModel):
     label: Optional[str] = None
 
 
-class IDName(BaseModel):
+class IDName(pydantic_v1.BaseModel):
     """Tuple containing `id` and `name`."""
 
     id: ID
     name: Optional[str] = None
 
 
-class IDLayer(BaseModel):
+class IDLayer(pydantic_v1.BaseModel):
     """Tuple containing `id` and `layer`."""
 
     id: ID
@@ -89,7 +90,7 @@ class IDLayer(BaseModel):
     label: Optional[str] = None
 
 
-class IDNameLayer(BaseModel):
+class IDNameLayer(pydantic_v1.BaseModel):
     """Triple holding `id`, `name`, and `layer`."""
 
     id: ID
@@ -97,7 +98,7 @@ class IDNameLayer(BaseModel):
     name: Optional[str] = None
 
 
-class Node(ABC, IDName, BaseModel):
+class Node(ABC, IDName, pydantic_v1.BaseModel):
     """
     Abstract Base Class holding a node of a tree.
 
@@ -113,7 +114,7 @@ class Node(ABC, IDName, BaseModel):
     parent: Optional[List[IDNameLayer]] = None
 
 
-class Tag(BaseModel):
+class Tag(pydantic_v1.BaseModel):
     """
 
     Represents a property that is associated with a period of time.
@@ -129,7 +130,7 @@ class Tag(BaseModel):
     end_timestamp: Optional[ISODate] = None
 
 
-class Flag(BaseModel):
+class Flag(pydantic_v1.BaseModel):
     """
 
     Represents a property that is associated with a vessel's flag.
@@ -146,7 +147,7 @@ class Flag(BaseModel):
     flag_country: Optional[str] = None
 
 
-class Scrubber(BaseModel):
+class Scrubber(pydantic_v1.BaseModel):
     """
 
     Represents information about scrubbers fitted to a vessel.
@@ -163,7 +164,7 @@ class Scrubber(BaseModel):
     planned: Optional[bool] = None
 
 
-class VesselClassEntry(BaseModel):
+class VesselClassEntry(pydantic_v1.BaseModel):
     """
 
     Represents a property that is associated with  the classes of a vessel.

--- a/vortexasdk/api/storage_terminal.py
+++ b/vortexasdk/api/storage_terminal.py
@@ -1,23 +1,24 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
+
 from typing import List, Optional
 
 
 from vortexasdk.api.shared_types import IDNameLayer
 
 
-class TerminalHierarchy(BaseModel):
+class TerminalHierarchy(pydantic_v1.BaseModel):
     id: Optional[str] = None
     label: Optional[str] = None
     layer: Optional[str] = None
 
 
-class TerminalParent(BaseModel):
+class TerminalParent(pydantic_v1.BaseModel):
     id: Optional[str] = None
     layer: Optional[List[str]] = None
     name: Optional[str] = None
 
 
-class StorageTerminal(BaseModel):
+class StorageTerminal(pydantic_v1.BaseModel):
     """
     Represents a Storage Terminal reference record returned by the API.
     """

--- a/vortexasdk/api/timeseries_item.py
+++ b/vortexasdk/api/timeseries_item.py
@@ -1,17 +1,17 @@
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 
 from vortexasdk.api import ISODate
 
 
-class TimeSeriesBreakdownItem(BaseModel):
+class TimeSeriesBreakdownItem(pydantic_v1.BaseModel):
     id: Optional[str] = None
     label: Optional[str] = None
     value: Optional[float] = None
     count: Optional[int] = None
 
 
-class TimeSeriesItem(BaseModel):
+class TimeSeriesItem(pydantic_v1.BaseModel):
     """
     Generic container class holding a `key <> value` pair, a `count` of records contributing to the given value.
 

--- a/vortexasdk/api/vessel.py
+++ b/vortexasdk/api/vessel.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
+
 from typing import List, Optional
 
 from vortexasdk.api.id import ID
@@ -14,7 +15,7 @@ from vortexasdk.api.shared_types import (
 )
 
 
-class VesselEntityCorporateEntity(BaseModel):
+class VesselEntityCorporateEntity(pydantic_v1.BaseModel):
     id: ID
     label: Optional[str] = None
     layer: Optional[str] = None
@@ -22,7 +23,7 @@ class VesselEntityCorporateEntity(BaseModel):
     start_timestamp: Optional[ISODate] = None
 
 
-class VesselEntityCorporateEntityWithConfidence(BaseModel):
+class VesselEntityCorporateEntityWithConfidence(pydantic_v1.BaseModel):
     probability: Optional[float] = None
     source: Optional[str] = None
     id: Optional[ID] = None

--- a/vortexasdk/api/vessel_availability.py
+++ b/vortexasdk/api/vessel_availability.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import List, Optional
 
 
@@ -11,7 +11,7 @@ from vortexasdk.api.shared_types import (
 )
 
 
-class DeclaredDestination(BaseModel):
+class DeclaredDestination(pydantic_v1.BaseModel):
     """
 
     Current destination location, as reported by the available vessel
@@ -23,7 +23,7 @@ class DeclaredDestination(BaseModel):
     vessel_id: Optional[str] = None
 
 
-class VesselFixtures(BaseModel):
+class VesselFixtures(pydantic_v1.BaseModel):
     """
 
     Current fixture information for the available vessel
@@ -38,7 +38,7 @@ class VesselFixtures(BaseModel):
     laycan_to: Optional[ISODate] = None
 
 
-class VesselAvailability(BaseModel):
+class VesselAvailability(pydantic_v1.BaseModel):
     """
 
     Vessel Availability shows vessels that are available to load a given cargo at a given port within a specified time range.

--- a/vortexasdk/api/vessel_positions.py
+++ b/vortexasdk/api/vessel_positions.py
@@ -1,11 +1,11 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 from typing import Optional
 from vortexasdk.api.id import ID
 
 from vortexasdk.api.shared_types import ISODate
 
 
-class VesselPositions(BaseModel):
+class VesselPositions(pydantic_v1.BaseModel):
     """
     Represents an AIS Vessel Position record returned by the API.
 

--- a/vortexasdk/api/vessel_summary.py
+++ b/vortexasdk/api/vessel_summary.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
+
 from typing import Optional
 
 from vortexasdk.api.id import ID
@@ -6,7 +7,7 @@ from vortexasdk.api.id import ID
 from vortexasdk.api.shared_types import ISODate
 
 
-class VesselSummary(BaseModel):
+class VesselSummary(pydantic_v1.BaseModel):
     """
     Represents a Vessel Summary record returned by the API.
 

--- a/vortexasdk/api/voyages.py
+++ b/vortexasdk/api/voyages.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
+
 from typing import List, Optional, Union
 from typing_extensions import Literal
 from vortexasdk.api.id import ID
@@ -15,7 +16,7 @@ from vortexasdk.api.shared_types import (
 )
 
 
-class CongestionBreakdownItem(BaseModel):
+class CongestionBreakdownItem(pydantic_v1.BaseModel):
     """
 
     Congestion breakdown shows various stats of vessels in congestion.
@@ -38,7 +39,7 @@ class CongestionBreakdownItem(BaseModel):
     location_details: Optional[List[EntityWithListLayer]] = None
 
 
-class VoyagesVesselEntity(BaseModel):
+class VoyagesVesselEntity(pydantic_v1.BaseModel):
     """
     A VoyagesVesselEntity represents a vessel record used in Voyages.
 
@@ -63,7 +64,7 @@ class VoyagesVesselEntity(BaseModel):
     vessel_risk_level: Optional[str] = None
 
 
-class VoyageVesselEvent(BaseModel):
+class VoyageVesselEvent(pydantic_v1.BaseModel):
     """
     A vessel event represents an activity that a vessel has performed during a voyage
 
@@ -96,7 +97,7 @@ class VoyageVesselEvent(BaseModel):
     ] = None
 
 
-class VoyageCargoEvent(BaseModel):
+class VoyageCargoEvent(pydantic_v1.BaseModel):
     """
     Cargo events relate to the movement of cargo during the voyage.
 
@@ -128,7 +129,7 @@ class VoyageCargoEvent(BaseModel):
     is_open_event: Optional[bool] = None
 
 
-class VoyageStatusEvent(BaseModel):
+class VoyageStatusEvent(pydantic_v1.BaseModel):
     """
     Status events describe the status of the voyage at a given period.
 
@@ -148,7 +149,7 @@ class VoyageStatusEvent(BaseModel):
     is_open_event: Optional[bool] = None
 
 
-class VoyageEnrichedItem(BaseModel):
+class VoyageEnrichedItem(pydantic_v1.BaseModel):
     """
 
     A voyage is defined as a continuous period of time when the vessel is either laden or ballast.

--- a/vortexasdk/endpoints/voyages_breakdown_result.py
+++ b/vortexasdk/endpoints/voyages_breakdown_result.py
@@ -3,7 +3,8 @@ import os
 from multiprocessing.pool import Pool
 import pandas as pd
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
+
 from vortexasdk.api.id import ID
 
 from vortexasdk.api.entity_flattening import convert_to_flat_dict
@@ -34,7 +35,7 @@ def sort_breakdown(item: dict, full_header_column: list):
     return item
 
 
-class VoyagesBreakdownItem(BaseModel):
+class VoyagesBreakdownItem(pydantic_v1.BaseModel):
     """
     Generic container class holding a `id <> value` pair, a `label`.
 


### PR DESCRIPTION
This PR changes our dependency requirements to no longer use Pydantic v1. 

>Pydantic V2 is a ground-up rewrite that offers many new features, performance improvements, and some breaking changes compared to Pydantic V1.

>If you're using Pydantic V1 you may want to look at the [pydantic V1.10 Documentation](https://docs.pydantic.dev/) or, [1.10.X-fixes git branch](https://github.com/pydantic/pydantic/tree/1.10.X-fixes). Pydantic V2 also ships with the latest version of Pydantic V1 built in so that you can incrementally upgrade your code base and projects: from pydantic import v1 as pydantic_v1.

We can still use the v1 code whilst setting a min version of v2.