### PR TITLE
chore: bump resource class for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ jobs:
     working_directory: ~/project
     docker:
       - image: cimg/python:3.9.0
+    resource_class: large
     steps:
       - checkout
       - restore_cache: &restore_cache


### PR DESCRIPTION
Tests task in CI is failing due to memory issues, bumping resource_class for that specific task.