### PR TITLE
docs(rnd-13503): remove decommissioned slow movement status

### DIFF
--- a/vortexasdk/endpoints/voyages_congestion_breakdown.py
+++ b/vortexasdk/endpoints/voyages_congestion_breakdown.py
@@ -116,7 +116,7 @@ class VoyagesCongestionBreakdown(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_geography_breakdown.py
+++ b/vortexasdk/endpoints/voyages_geography_breakdown.py
@@ -149,7 +149,7 @@ class VoyagesGeographyBreakdown(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_product_breakdown.py
+++ b/vortexasdk/endpoints/voyages_product_breakdown.py
@@ -149,7 +149,7 @@ class VoyagesProductBreakdown(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_routes_breakdown.py
+++ b/vortexasdk/endpoints/voyages_routes_breakdown.py
@@ -148,7 +148,7 @@ class VoyagesRoutesBreakdown(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_search_enriched.py
+++ b/vortexasdk/endpoints/voyages_search_enriched.py
@@ -127,7 +127,7 @@ class VoyagesSearchEnriched(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_timeseries.py
+++ b/vortexasdk/endpoints/voyages_timeseries.py
@@ -128,7 +128,7 @@ class VoyagesTimeseries(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_timeseries_v2.py
+++ b/vortexasdk/endpoints/voyages_timeseries_v2.py
@@ -143,7 +143,7 @@ class VoyagesTimeseriesV2(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_top_hits.py
+++ b/vortexasdk/endpoints/voyages_top_hits.py
@@ -127,7 +127,7 @@ class VoyagesTopHits(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 

--- a/vortexasdk/endpoints/voyages_vessel_class_breakdown.py
+++ b/vortexasdk/endpoints/voyages_vessel_class_breakdown.py
@@ -146,7 +146,7 @@ class VoyagesVesselClassBreakdown(Search):
 
             voyage_status_excluded: A voyage status, or list of voyage statuses to exclude.
 
-            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`, `'slow'`.
+            movement_status: A movement status, or list of movement statuses to filter on. Can be one of: `'moving'`, `'stationary'`, `'waiting'`, `'congestion'`.
 
             movement_status_excluded: A movement status, or list of movement statuses to exclude.
 


### PR DESCRIPTION
#### RELATED TICKETS

- [RND-13503](https://vortexa.atlassian.net/browse/RND-13503)

#### CHANGELOG

- Removed `'slow'` from the documented `movement_status` values in the Voyages endpoint docstrings. It
  was decommissioned over two years ago and the API now rejects it.

#### TESTS

- Nothing manual. Docstrings only, no behavior change.

#### COMMENTS

- No `version.py` bump, matching the previous docstring-only change (#563).

[RND-13503]: https://vortexa.atlassian.net/browse/RND-13503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ